### PR TITLE
workloads: Add ocs-operator default vars

### DIFF
--- a/workloads/workload_vars/ocs-operator.yml
+++ b/workloads/workload_vars/ocs-operator.yml
@@ -1,0 +1,2 @@
+---
+ocs_mcg_core_mem: 1Gi


### PR DESCRIPTION
Add ocs-operator workload default vars to ensure proper functioning of the role, default taken from summit 2020 vars.