### PR TITLE
Pass uuid to use in Cloud Formation templates

### DIFF
--- a/3.x/ocp3_vars.yml
+++ b/3.x/ocp3_vars.yml
@@ -40,3 +40,4 @@ nfs_server_address: "support1.{{ guid }}{{ subdomain_base_suffix }}"
 # of a deleted OCP cluster's files
 archive_dir: "{{ output_dir | dirname }}/archive"
 
+uuid: "{{ guid }}"

--- a/4.x/ocp4_vars.yml
+++ b/4.x/ocp4_vars.yml
@@ -45,3 +45,4 @@ worker_instance_count: 3
 archive_dir: "{{ output_dir | dirname }}/archive"
 
 _infra_node_instance_type: "m4.large"
+uuid: "{{ guid }}"


### PR DESCRIPTION
A recent PR in agnosticd introduced `uuid` as tags in AWS resources which has a default value of `''` It breaks when no uuid is specified. This PR is a workaround to pass uuid some value other than empty string.