### PR TITLE
ocp3 migration python path is not /usr/bin/python

### DIFF
--- a/workloads/deploy_workload.sh
+++ b/workloads/deploy_workload.sh
@@ -12,7 +12,7 @@ Options :
   -a    Action ('create' or 'remove')
   -m    my_vars.yml directory (optional)
 
-Note : 
+Note :
   Make sure your cluster was launched using mig-agnosticd
 
 Example Usage :
@@ -34,7 +34,7 @@ while getopts ':hw:v:a:m:' option; do
        ;;
     v) OCP=$OPTARG
        MY_VARS_DIR="../${OCP}.x"
-       ;; 
+       ;;
     a) ACTION=$OPTARG
        ;;
     m) MY_VARS_DIR="$OPTARG"

--- a/workloads/workload.yml
+++ b/workloads/workload.yml
@@ -93,4 +93,4 @@
       ansible_user: ec2-user
       playbook_dir: "{{ agnosticd_home }}"
       hosts: remote
-      ansible_python_interpreter: "{{ '/usr/bin/python' if ocp_version == '3' else '/opt/virtualenvs/k8s/bin/python' }}"
+      ansible_python_interpreter: "{{ '/opt/virtualenvs/k8s-wload-migration/bin/python' if ocp_version == '3' else '/opt/virtualenvs/k8s/bin/python' }}"


### PR DESCRIPTION
**SUMMARY**
For OCP-3 migration install e.g.
./deploy_workload.sh -a create -w migration -v 3

set the python path to:
/opt/virtualenvs/k8s-wload-migration

**ISSUE TYPE**
* Bugfix Pull Request

