### PR TITLE
ocp4_workshop is deprecrated, default to cluster

### DIFF
--- a/4.x/delete_ocp4_workshop.sh
+++ b/4.x/delete_ocp4_workshop.sh
@@ -6,6 +6,6 @@ if [[ -z "${AGNOSTICD_HOME}" ]]; then
 fi
 
 pushd .
-cd ${AGNOSTICD_HOME} 
-ansible-playbook  ./ansible/configs/ocp4-workshop/destroy_env.yml ${OUR_DIR}/../archive_deleted.yml -e @${OUR_DIR}/my_vars.yml -e @${OUR_DIR}/ocp4_vars.yml -e @${OUR_DIR}/../secret.yml "$@"
+cd ${AGNOSTICD_HOME}
+ansible-playbook  ./ansible/configs/ocp4-cluster/destroy_env.yml ${OUR_DIR}/../archive_deleted.yml -e @${OUR_DIR}/my_vars.yml -e @${OUR_DIR}/ocp4_vars.yml -e @${OUR_DIR}/../secret.yml "$@"
 popd

--- a/4.x/ocp4_vars.yml
+++ b/4.x/ocp4_vars.yml
@@ -1,5 +1,6 @@
 cloudformation_retries: 0
-env_type: ocp4-workshop
+env_type: ocp4-cluster
+# env_type: ocp4-workshop #ocp4-workshop is now deprecated
 software_to_deploy: none
 
 ocp4_installer_version: "4.8.0"


### PR DESCRIPTION
**SUMMARY**
For OCP-4x deletion 
ocp4_workshop should no longer be used, please use
ocp4_cluster henceforth. Update delete_ocp4_workshop.sh
to use the "cluster" not "workshop" config.

**Depends-On:** 
https://github.com/konveyor/agnosticd/pull/9

**ISSUE TYPE**
* Bugfix Pull Request


