### PR TITLE
Update the OCP4 deployer to use ocp4-cluster env

### DIFF
--- a/4.x/ocp4_vars.yml
+++ b/4.x/ocp4_vars.yml
@@ -1,10 +1,11 @@
 cloudformation_retries: 0
-env_type: ocp4-workshop
-software_to_deploy: none
+env_type: ocp4-cluster
+software_to_deploy: openshift4
 
 ocp4_installer_version: "4.8.12"
 osrelease: "4.6.0"
-bastion_instance_type: t2.medium
+
+update_packages: true
 install_ocp4: true
 
 # Next settings are for Dev Preview releases of OpenShift
@@ -16,9 +17,12 @@ install_ocp4: true
 
 install_opentlc_integration: false
 install_idm: htpasswd
-user_count: 20
-user_password: r3dh4t1!
 install_ipa_client: false
+install_ftl: false
+smoke_tests: false
+
+# Set authentication passwords in secret file
+ocp4_workload_authentication_htpasswd_user_count: 0
 
 # We are intentionally setting the below to empty to reduce setup time
 # and skip deploying workloads we are not interested in.
@@ -44,5 +48,4 @@ worker_instance_count: 3
 # of a deleted OCP cluster's files
 archive_dir: "{{ output_dir | dirname }}/archive"
 
-_infra_node_instance_type: "m4.large"
 uuid: "{{ guid }}"

--- a/secret.yml.sample
+++ b/secret.yml.sample
@@ -2,33 +2,45 @@
 aws_access_key_id: "REPLACE_WITH_ACCESS_KEY_ID"
 aws_secret_access_key: "REPLACE_WITH_SECRET_ACCESS_KEY"
 
-# User credentials for access.redhat.com 
+# User credentials for access.redhat.com
 # Used to fetch images from registry.redhat.io
 redhat_registry_user: "replace_with_portal_credentials"
 redhat_registry_password: "portal_password"
 
 #
 # Obtain the token by going to try.openshift.com
-# Be sure that when you add your token in you use ' ' 
+# Be sure that when you add your token in you use ' '
 # The token will contain " inside of it, you need to wrap with ' to escape
-# Make sure your token looks like this : 
+# Make sure your token looks like this :
 # ocp4_pull_secret: '{"auths":{"cloud.openshift.com":{"auth":"<SOME_VALUE>","email":"john@doe.com"},"quay.io":{"auth":"<SOME_VALUE>","email":"john@doe.com"},"registry.connect.redhat.com":{"auth":"<SOME_OTHER_VALUE>","email":"john@doe.com"},"registry.redhat.io":{"auth":"<SOME_OTHER_VALUE>","email":"john@doe.com"}}}'
 ocp4_pull_secret: '<REPLACE_ME_WITH_TOKEN>'
 
 #
 # Below is if you have a mirror of content you want to use
 # Reach out to one of the developers if you need access to an internal mirror we have
-# 
-own_repo_path: "http://REPLACE_ME/repos/ocp/{{ osrelease }}/"
-
-
-# If not using, 'own_repo_path', you need to supply credentials for 
-# subscription manager to register for yum content 
 #
-# Uncomment the below if you are not using 
+# own_repo_path: "http://REPLACE_ME/repos/ocp/{{ osrelease }}/"
+
+repo_method: satellite
+
+# If not using, 'own_repo_path', you need to supply credentials for
+# subscription manager to register for yum content
+#
+# Uncomment the below if you are not using
 # 'own_repo_path' and enter credentials for subscription manager
 #
 #rhel_subscription_user: "replace_with_username"
 #rhel_subscription_pass: "replace_with_password"
 #repo_method="rhn"
-#rhn_pool_id_string="Employee SKU" 
+#rhn_pool_id_string="Employee SKU"
+
+# If you are using satellite as a repository, set the following:
+# Variables to be set are:
+#satellite_url: your.satellite.host
+#set_repositories_satellite_url: "{{ satellite_url }}"
+#satellite_org: your_org
+#set_repositories_satellite_org: "{{ satellite_org }}"
+#satellite_activationkey: activation_key
+#set_repositories_satellite_activationkey: "{{ satellite_activationkey }}"
+
+


### PR DESCRIPTION
The ocp4-workshop environment is no longer maintained upstream.
In order to have the environment which is the same as the real lab, we need to switch the configuration to ocp4-cluster. 