### PR TITLE
enable FIPS in 4.x by default

### DIFF
--- a/4.x/ocp4_vars.yml
+++ b/4.x/ocp4_vars.yml
@@ -7,6 +7,7 @@ osrelease: "4.6.0"
 
 update_packages: true
 install_ocp4: true
+ocp4_fips_enable: true
 
 # Next settings are for Dev Preview releases of OpenShift
 # These will override the installer version with the direct downloads


### PR DESCRIPTION
FIPS checks and details are here: https://issues.redhat.com/browse/OADP-63
As far as we can all of our 4.x projects will have to be FIPS compliant.