### PR TITLE
enable FIPS in 4.x by default

### DIFF
--- a/4.x/ocp4_vars.yml
+++ b/4.x/ocp4_vars.yml
@@ -7,6 +7,7 @@ osrelease: "4.6.0"
 
 update_packages: true
 install_ocp4: true
+ocp4_fips_enable: true
 
 # Next settings are for Dev Preview releases of OpenShift
 # These will override the installer version with the direct downloads

--- a/4.x/ocp4_vars.yml
+++ b/4.x/ocp4_vars.yml
@@ -7,7 +7,10 @@ osrelease: "4.6.0"
 
 update_packages: true
 install_ocp4: true
-ocp4_fips_enable: true
+# note konveyor projects will be expected to ship w/ FIPS compliance
+# https://docs.openshift.com/container-platform/4.9/installing/installing-fips.html
+# https://github.com/redhat-cop/agnosticd/blob/development/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2#L6
+# ocp4_fips_enable: true
 
 # Next settings are for Dev Preview releases of OpenShift
 # These will override the installer version with the direct downloads

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Additionally we will install:
 
 
 # How are the environments provisioned
-This repository is simply configuration files to drive https://github.com/redhat-cop/agnosticd, 'agnosticd' is a collection of Ansible configs/roles we are leveraging to deploy our OCP environments.  
+This repository is simply configuration files to drive https://github.com/redhat-cop/agnosticd, 'agnosticd' is a collection of Ansible configs/roles we are leveraging to deploy our OCP environments.
 
 The installation of the Velero and Migration bits are handled via roles in agnosticd which are leveraging the below operators:
   - https://github.com/konveyor/velero-operator
@@ -55,7 +55,7 @@ At this point in time, the operators are _not_ integrated with OLM.  The intent 
 
     - Admin Access is currently required for OCP 4.x
     - Access to a HostedZone in AWS Route53 is required, meaning you need a domain name managed by Route53 which can serve as the subdomain for your clusters
-1. Checkout of https://github.com/redhat-cop/agnosticd 
+1. Checkout of https://github.com/redhat-cop/agnosticd
 1. Environment Variable set of 'AGNOSTICD_HOME' pointing to your agnosticd checkout
 1. Creation of a 'secret.yml' in the base directory of this repo, see https://github.com/konveyor/mig-agnosticd/blob/master/secret.yml.sample
 
@@ -66,11 +66,11 @@ At this point in time, the operators are _not_ integrated with OLM.  The intent 
 
 # Pre-provisioning Steps
 ```
-# Clone 'agnosticd' repo, which 'mig-agnosticd' (this repo) will call into for provisioning 
+# Clone 'agnosticd' repo, which 'mig-agnosticd' (this repo) will call into for provisioning
 git clone https://github.com/redhat-cop/agnosticd.git
 cd agnosticd
 export AGNOSTICD_HOME=`pwd`  # Consider exporting 'AGNOSTICD_HOME' in ~/.bashrc to the full repo path for future use.
-cd .. 
+cd ..
 
 # Clone 'mig-agnosticd' repo (this repo)
 git clone https://github.com/konveyor/mig-agnosticd.git
@@ -78,7 +78,7 @@ cd mig-agnosticd
 cp secret.yml.sample secret.yml
 vim secret.yml # Update based on comments in file
 
-# Fill out required vars for provisioning OpenShift 3.x 
+# Fill out required vars for provisioning OpenShift 3.x
 cd 3.x
 cp my_vars.yml.sample my_vars.yml
 vim my_vars.yml # Update based on comments in file
@@ -89,6 +89,12 @@ cd 4.x
 cp my_vars.yml.sample my_vars.yml
 vim my_vars.yml # Update based on comments in file
 cd ..
+```
+
+# FIPS - note a fips option has been added to ocp4_vars.yml
+FIPS is disabled by default.
+```
+# ocp4_fips_enable: true
 ```
 
 ## Virtualenv (optional)
@@ -107,7 +113,7 @@ cd ..
  * To update any requirements
     ```
     pip3 freeze > requirements.txt
-    ``` 
+    ```
 
 
 ## Running AgnosticD to provision OpenShift 3 + 4 Clusters
@@ -115,9 +121,9 @@ cd ..
 Before provisioning, ensure you have populated all necessary vars in:
  - `./secret.yml`
  - `./3.x/my_vars.yml`
- - `./4.x/my_vars.yml` 
+ - `./4.x/my_vars.yml`
 
 **To provision an OpenShift Cluster with AgnosticD:**
- - 3.x cluster, see [./3.x/README.md](https://github.com/konveyor/mig-agnosticd/blob/master/3.x/README.md). 
+ - 3.x cluster, see [./3.x/README.md](https://github.com/konveyor/mig-agnosticd/blob/master/3.x/README.md).
  - 4.x cluster, see [./4.x/README.md](https://github.com/konveyor/mig-agnosticd/blob/master/4.x/README.md).
 


### PR DESCRIPTION
FIPS checks and details are here: https://issues.redhat.com/browse/OADP-63
As far as we can all of our 4.x projects will have to be FIPS compliant.