### PR TITLE
Bumped requirements.txt based on working with changes to agnosticd

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-ansible==2.9.15
+ansible==5.6.0
+ansible-core==2.12.4
 awscli==1.21.0
 boto==2.49.0
 boto3==1.19.0
@@ -10,11 +11,14 @@ docutils==0.15.2
 Jinja2==3.0.2
 jmespath==0.10.0
 MarkupSafe==2.0.1
+packaging==21.3
 passlib==1.7.4
 pyasn1==0.4.8
 pycparser==2.20
+pyparsing==3.0.8
 python-dateutil==2.8.2
 PyYAML==5.4.1
+resolvelib==0.5.4
 rsa==4.7.2
 s3transfer==0.5.0
 six==1.16.0


### PR DESCRIPTION
I also needed to manually install the below requirements.yml.

`ansible-galaxy install -r ${AGNOSTICD_HOME}/ansible/configs/ocp4-cluster/requirements.yml`

I suspect something isn't right with using virtualenvs and https://github.com/redhat-cop/agnosticd/blob/9a1b2ed82727a69f3258841ff9eeaaa97b0cb292/ansible/setup_runtime.yml


I only tested with:

- create_ocp4_workshop.sh
- delete_ocp4_workshop.sh


I was under impression there was an issue with ocp3 and I did NOT test ocp3.