### PR TITLE
Fix deletion of the OCP4 cluster

### DIFF
--- a/4.x/delete_ocp4_workshop.sh
+++ b/4.x/delete_ocp4_workshop.sh
@@ -14,5 +14,5 @@ fi
 
 pushd .
 cd ${AGNOSTICD_HOME}
-ansible-playbook  ./ansible/configs/ocp4-cluster/destroy_env.yml ${OUR_DIR}/../archive_deleted.yml -e ACTION="destroy" -e @${OUR_DIR}/ocp4_vars.yml -e @${OUR_DIR}/my_vars.yml -e @${OUR_DIR}/../secret.yml "$@"
+ansible-playbook  ./ansible/configs/ocp4-cluster/destroy_env.yml ${OUR_DIR}/../archive_deleted.yml -e @./ansible/configs/ocp4-cluster/default_vars.yml -e ACTION="destroy" -e @${OUR_DIR}/ocp4_vars.yml -e @${OUR_DIR}/my_vars.yml -e @${OUR_DIR}/../secret.yml "$@"
 popd


### PR DESCRIPTION
Adds default vars to the env, so agnosticd is not complaining about Ansible undefined variables (like project_tag).